### PR TITLE
WIP: Support compiled tests

### DIFF
--- a/cmd/executor.go
+++ b/cmd/executor.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Unbabel/replicant/internal/executor"
 	"github.com/Unbabel/replicant/log"
 	"github.com/Unbabel/replicant/transaction"
+	"github.com/Unbabel/replicant/volume"
 	"github.com/julienschmidt/httprouter"
 	"github.com/spf13/cobra"
 )
@@ -29,6 +30,8 @@ func init() {
 	Executor.Flags().Bool("chrome-enable-local", false, "Enable running a local chrome worker process for web transactions")
 	Executor.Flags().String("chrome-local-command", "/headless-shell/headless-shell --headless --no-zygote --no-sandbox --disable-gpu --disable-software-rasterizer --disable-dev-shm-usage --remote-debugging-address=127.0.0.1 --remote-debugging-port=9222 --incognito --disable-shared-workers --disable-remote-fonts --disable-background-networking --disable-crash-reporter --disable-default-apps --disable-domain-reliability --disable-extensions --disable-shared-workers --disable-setuid-sandbox", "Command for launching chrome with arguments included")
 	Executor.Flags().Duration("chrome-recycle-interval", time.Minute*5, "Chrome recycle interval for locally managed chrome process")
+	Executor.Flags().String("shared-volume", "/tmp", "Path of the shared volume that is required to store the test binaries")
+
 }
 
 // Executor command
@@ -40,6 +43,7 @@ var Executor = &cobra.Command{
 		config := executor.Config{}
 		config.ServerURL = cmdutil.GetFlagString(cmd, "server-url")
 		config.AdvertiseURL = cmdutil.GetFlagString(cmd, "webhook-advertise-url")
+		config.Volume = volume.New(cmdutil.GetFlagString(cmd, "shared-volume"))
 
 		// Setup chrome support for web applications
 		config.Web.ServerURL = cmdutil.GetFlagString(cmd, "chrome-remote-url")

--- a/cmd/txn.go
+++ b/cmd/txn.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"fmt"
+	"io/ioutil"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -14,6 +16,7 @@ func init() {
 	Txn.PersistentFlags().StringP("file", "f", "", "Path to transaction definition file")
 	Txn.PersistentFlags().Bool("insecure", false, "Skip server certificate verification")
 	Txn.PersistentFlags().DurationP("timeout", "t", 5*time.Minute, "Replicant server timeout for running transactions")
+	Txn.PersistentFlags().StringP("binary", "b", "", "The binary with the compiled test. Required with the go_binary driver")
 	Txn.AddCommand(Add)
 	Txn.AddCommand(Get)
 	Txn.AddCommand(Run)
@@ -28,4 +31,17 @@ var Txn = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		cmd.Usage()
 	},
+}
+
+func loadFile(path string) ([]byte, error) {
+	if path == "" {
+		return nil, fmt.Errorf("path must be specified")
+	}
+
+	buf, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("Error reading file '%s': %s", path, err)
+	}
+
+	return buf, nil
 }

--- a/cmd/txn_add.go
+++ b/cmd/txn_add.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"io/ioutil"
-
 	"github.com/Unbabel/replicant/client"
 	"github.com/Unbabel/replicant/internal/cmdutil"
 	"github.com/Unbabel/replicant/transaction"
@@ -18,18 +16,21 @@ var Add = &cobra.Command{
 		var err error
 		var tx transaction.Config
 
-		file := cmdutil.GetFlagString(cmd, "file")
-		if file == "" {
-			die("Transaction file must be specified")
-		}
-
-		buf, err := ioutil.ReadFile(file)
+		buf, err := loadFile(cmdutil.GetFlagString(cmd, "file"))
 		if err != nil {
-			die("Error reading transaction: %s", err)
+			die("Error reading transaction file: %s", err)
 		}
 
 		if err = yaml.Unmarshal(buf, &tx); err != nil {
-			die("Error reading transaction: %s", err)
+			die("Error reading transaction file: %s", err)
+		}
+
+		if tx.Driver == "go_binary" {
+			buf, err := loadFile(cmdutil.GetFlagString(cmd, "binary"))
+			if err != nil {
+				die("Error reading transaction's binary: %s", err)
+			}
+			tx.Binary = buf
 		}
 
 		c, err := client.New(client.Config{

--- a/driver/go_binary/driver.go
+++ b/driver/go_binary/driver.go
@@ -1,0 +1,81 @@
+// Package gd implements a Go transaction driver.
+package gbd
+
+/*
+   Copyright 2019 Bruno Moura <brunotm@gmail.com>
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+import (
+	"context"
+	"fmt"
+	"plugin"
+	"time"
+
+	"github.com/Unbabel/replicant/driver"
+	"github.com/Unbabel/replicant/transaction"
+	"github.com/Unbabel/replicant/volume"
+)
+
+// Driver for Go binary based transactions
+type Driver struct {
+	volume *volume.Volume
+}
+
+// New creates a new Go driver for binaries
+func New(volume *volume.Volume) (d driver.Driver, err error) {
+	return &Driver{volume: volume}, nil
+}
+
+// Type returns this driver type
+func (d *Driver) Type() (t string) {
+	return "go_binary"
+}
+
+// New creates a web transaction
+func (d *Driver) New(config transaction.Config) (tx transaction.Transaction, err error) {
+	txn := &Transaction{}
+
+	if config.Timeout != "" {
+		txn.timeout, err = time.ParseDuration(config.Timeout)
+		if err != nil {
+			return nil, fmt.Errorf("driver/go_binary: error parsing timeout: %w", err)
+		}
+	}
+
+	location, err := d.volume.Location(config.Name + ".so")
+	if err != nil {
+		return nil, fmt.Errorf("driver/go_binary: %w", err)
+	}
+
+	p, err := plugin.Open(location)
+	if err != nil {
+		return nil, fmt.Errorf("driver/go_binary: error loading the binary: %w", err)
+	}
+
+	symbol, err := p.Lookup("Run")
+	if err != nil {
+		return nil, fmt.Errorf("driver/go_binary: error locating the entrypoint of the binary: %w", err)
+	}
+
+	var ok bool
+	txn.transaction, ok = symbol.(func(context.Context) (message, data string, err error))
+	if !ok || txn.transaction == nil {
+		return nil, fmt.Errorf(
+			`driver/go_binary: entrypoint Run doesn't implement "func(context.Context) (message, data string, err error)" signature`)
+	}
+
+	txn.config = config
+	return txn, nil
+}

--- a/driver/go_binary/transaction.go
+++ b/driver/go_binary/transaction.go
@@ -1,0 +1,112 @@
+package gbd
+
+/*
+   Copyright 2019 Bruno Moura <brunotm@gmail.com>
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/Unbabel/replicant/transaction"
+	"github.com/Unbabel/replicant/transaction/callback"
+)
+
+// TxFunc is the Run function signature which will be called from the provided go code.
+// Package name must be transaction, "transaction.Run".
+type TxFunc func(context.Context) (message, data string, err error)
+
+// CallBackHandler is the Handle function signature which will be called from the provided go code
+// when dealing with callbacks. Package name must be callback, "callback.Handle"
+type CallBackHandler func(context.Context, []byte) (message, data string, err error)
+
+// Transaction is a pre-compiled replicant transaction for golang based custom transactions
+type Transaction struct {
+	config          transaction.Config
+	timeout         time.Duration
+	transaction     TxFunc
+	callbackHandler CallBackHandler
+}
+
+// Config returns the transaction config
+func (t *Transaction) Config() (config transaction.Config) {
+	return t.config
+}
+
+// Run executes the web transaction
+func (t *Transaction) Run(ctx context.Context) (result transaction.Result) {
+	result.Name = t.config.Name
+	result.Driver = "go_binary"
+	result.Metadata = t.config.Metadata
+
+	var err error
+	var handle *callback.Handle
+
+	// If dealing with async responses for this transaction, we must first get a Listener and Handle
+	if t.config.CallBack != nil {
+		listener, ok := ctx.Value(t.config.CallBack.Type).(callback.Listener)
+		if !ok {
+			result.Failed = true
+			result.Error = fmt.Errorf("driver/go_binary: callback not found or does not implement callback.Listener interface")
+		}
+
+		handle, err = listener.Listen(ctx)
+		if err != nil {
+			result.Failed = true
+			result.Error = fmt.Errorf("driver/go_binary: error handling callback: %w", err)
+			return result
+		}
+
+		ctx = context.WithValue(ctx, "callback_address", handle.Address)
+	}
+
+	m, d, err := t.transaction(ctx)
+	if err != nil {
+		result.Error = fmt.Errorf("driver/go_binary: error running transaction: %w", err)
+		result.Message = m
+		result.Failed = true
+		return result
+	}
+
+	if t.config.CallBack == nil {
+		result.Message = m
+		result.Data = d
+		return result
+	}
+
+	// Handle async responses, recalculate duration after response
+	resp := <-handle.Response
+	result.WithCallback = true
+	result.DurationSeconds = time.Since(result.Time).Seconds()
+
+	if resp.Error != nil {
+		result.Error = fmt.Errorf("driver/go_binary: error from callback listener: %w", err)
+		result.Data = string(resp.Data)
+		result.Failed = true
+		return result
+	}
+
+	m, d, err = t.callbackHandler(ctx, resp.Data)
+	if err != nil {
+		err = fmt.Errorf("driver/go_binary: error running callback handler: %w", err)
+		result.Failed = true
+	}
+
+	result.Error = err
+	result.Message = m
+	result.Data = d
+	return result
+}

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -9,10 +9,12 @@ import (
 
 	"github.com/Unbabel/replicant/driver"
 	godriver "github.com/Unbabel/replicant/driver/go"
+	gobdriver "github.com/Unbabel/replicant/driver/go_binary"
 	"github.com/Unbabel/replicant/driver/javascript"
 	"github.com/Unbabel/replicant/driver/web"
 	"github.com/Unbabel/replicant/internal/xz"
 	"github.com/Unbabel/replicant/transaction"
+	"github.com/Unbabel/replicant/volume"
 )
 
 // Executor is the replicant execution service
@@ -26,6 +28,7 @@ type Config struct {
 	Web          web.Config
 	ServerURL    string
 	AdvertiseURL string
+	Volume       *volume.Volume
 }
 
 // New creates a new executor
@@ -51,6 +54,12 @@ func New(c Config) (e *Executor, err error) {
 	e.drivers.Store(drv.Type(), drv)
 
 	drv, err = godriver.New()
+	if err != nil {
+		return nil, err
+	}
+	e.drivers.Store(drv.Type(), drv)
+
+	drv, err = gobdriver.New(c.Volume)
 	if err != nil {
 		return nil, err
 	}

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -214,6 +214,18 @@ func (m *Manager) Add(config transaction.Config) (err error) {
 // Delete a transaction from the manager by name
 func (m *Manager) Delete(name string) (err error) {
 
+	txn, err := m.transactions.Get(name)
+	if err != nil {
+		return fmt.Errorf("manager: %w", err)
+	}
+
+	if txn.Driver == "go_binary" {
+		if err := m.volume.Delete(name); err != nil {
+			log.Error("error deleting the transaction's binary").
+				String("name", name).Error("error", err).Log()
+		}
+	}
+
 	if err = m.transactions.Delete(name); err != nil {
 		return fmt.Errorf("manager: %w", err)
 	}

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -195,7 +195,7 @@ func (m *Manager) Add(config transaction.Config) (err error) {
 	}
 
 	if config.Driver == "go_binary" {
-		if err := m.volume.Store(config.Name, config.Binary); err != nil {
+		if err := m.volume.Store(config.Name+".so", config.Binary); err != nil {
 			return fmt.Errorf("manager: failed to store the transaction's binary")
 		}
 

--- a/server/server.go
+++ b/server/server.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/Unbabel/replicant/log"
 	"github.com/Unbabel/replicant/manager"
+	"github.com/Unbabel/replicant/volume"
 	"github.com/julienschmidt/httprouter"
 )
 
@@ -37,6 +38,7 @@ type Config struct {
 	WriteTimeout      time.Duration `json:"write_timeout" yaml:"write_timeout"`
 	ReadTimeout       time.Duration `json:"read_timeout" yaml:"read_timeout"`
 	ReadHeaderTimeout time.Duration `json:"read_header_timeout" yaml:"read_header_timeout"`
+	SharedVolume      string        `json:"shared_volume" yaml:"shared_volume"`
 }
 
 // Server is an replicant manager and api server
@@ -45,6 +47,7 @@ type Server struct {
 	http    *http.Server
 	router  *httprouter.Router
 	manager *manager.Manager
+	volume  *volume.Volume
 }
 
 // New creates a new replicant server

--- a/transaction/transaction.go
+++ b/transaction/transaction.go
@@ -41,4 +41,5 @@ type Config struct {
 	CallBack   *callback.Config       `json:"callback" yaml:"callback"`
 	Inputs     map[string]interface{} `json:"inputs" yaml:"inputs"`
 	Metadata   map[string]string      `json:"metadata" yaml:"metadata"`
+	Binary     []byte                 `json:"binary" yaml:"binary"`
 }

--- a/volume/volume.go
+++ b/volume/volume.go
@@ -1,0 +1,43 @@
+package volume
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+)
+
+type Volume struct {
+	root string
+}
+
+func New(root string) *Volume {
+	return &Volume{root: root}
+}
+
+func (v *Volume) Store(name string, data []byte) error {
+	path := fmt.Sprintf("%s/%s", v.root, name)
+	err := ioutil.WriteFile(path, data, 0644)
+	if err != nil {
+		return fmt.Errorf("Error storing the binary: %s", name)
+	}
+	return nil
+}
+
+func (v *Volume) Delete(name string) error {
+	path := fmt.Sprintf("%s/%s", v.root, name)
+	err := os.Remove(path)
+	if err != nil {
+		return fmt.Errorf("Error deleting the binary: %s", name)
+	}
+	return nil
+}
+
+func (v *Volume) Location(name string) (string, error) {
+	path := fmt.Sprintf("%s/%s", v.root, name)
+	os.Stat(path)
+	_, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		return "", fmt.Errorf("Error locating the binary: %s", name)
+	}
+	return path, nil
+}


### PR DESCRIPTION
Here is the plan:
- [x] Change the transaction configuration to allow one to provide a path to a binary containing a struct implementing the transaction interface
- [x] Change the cli to recognize the binary path when it's provided and sent it to the server
- [x] Persist the binary in the file system for later execution
- [ ] Change server to load the binary using the plugin package and execute the compiled test
- [ ] Add integrity verification on the binary content 